### PR TITLE
handle uppercase column names

### DIFF
--- a/data/db_sql.go
+++ b/data/db_sql.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -129,6 +130,9 @@ func sqlColList(names []string, dbtypes map[string]string, addLeadingComma bool)
 
 // makeSQLColExpr casts a column to text if type is unknown to PGX
 func sqlColExpr(name string, dbtype string) string {
+
+	name = strconv.Quote(name)
+
 	// TODO: make this more data-driven / configurable
 	switch dbtype {
 	case forceTextTSVECTOR:
@@ -173,7 +177,7 @@ func sqlAttrFilter(filterConds []*FilterCond) (string, []interface{}) {
 	return sql, vals
 }
 
-const sqlFmtBBoxFilter = " ST_Intersects(%v, ST_Transform( ST_MakeEnvelope(%v, %v, %v, %v, 4326), %v)) "
+const sqlFmtBBoxFilter = ` ST_Intersects("%v", ST_Transform( ST_MakeEnvelope(%v, %v, %v, %v, 4326), %v)) `
 
 func sqlBBoxFilter(tbl *Table, bbox *Extent) string {
 	if bbox == nil {
@@ -185,7 +189,7 @@ func sqlBBoxFilter(tbl *Table, bbox *Extent) string {
 	return sql
 }
 
-const sqlFmtBBoxGeoFilter = " ST_Intersects(%v, ST_MakeEnvelope(%v, %v, %v, %v, 4326)) "
+const sqlFmtBBoxGeoFilter = ` ST_Intersects("%v", ST_MakeEnvelope(%v, %v, %v, %v, 4326)) `
 
 func sqlBBoxGeoFilter(geomCol string, bbox *Extent) string {
 	if bbox == nil {
@@ -196,7 +200,7 @@ func sqlBBoxGeoFilter(geomCol string, bbox *Extent) string {
 	return sql
 }
 
-const sqlFmtGeomCol = "ST_AsGeoJSON( ST_Transform(%v, 4326) %v ) AS _geojson"
+const sqlFmtGeomCol = `ST_AsGeoJSON( ST_Transform("%v", 4326) %v ) AS _geojson`
 
 func sqlGeomCol(geomCol string, param *QueryParam) string {
 	geomExpr := applyTransform(param.TransformFuns, geomCol)


### PR DESCRIPTION
Hello,
This PR puts quotes around column names to prevent errors if the columns have uppercase characters.

e.g.:
```sql
create table ucase_table (id serial primary key, "GEOMETRY" Geometry(Point, 4326), "UCASE_PROP" int);
insert into ucase_table ("GEOMETRY", "UCASE_PROP") values (ST_SetSRID(ST_MakePoint(-121,53), 4326), 3);
```