### PR TITLE
Improve timeout reporting

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,6 +56,25 @@ const (
 	GeoJSONFeatureCollection = "FeatureCollection"
 )
 
+const (
+	ErrMsgEncoding              = "Error encoding response"
+	ErrMsgLoadCollections       = "Unable to access Collections"
+	ErrMsgCollectionNotFound    = "Collection not found: %v"
+	ErrMsgCollectionAccess      = "Unable to access Collection: %v"
+	ErrMsgFeatureNotFound       = "Feature not found: %v"
+	ErrMsgLoadFunctions         = "Unable to access Functions"
+	ErrMsgFunctionNotFound      = "Function not found: %v"
+	ErrMsgFunctionAccess        = "Unable to access Function: %v"
+	ErrMsgInvalidParameterValue = "Invalid value for parameter %v: %v"
+	ErrMsgDataRead              = "Unable to read data from: %v"
+	ErrMsgRequestTimeout        = "Maximum time exceeded.  Request cancelled."
+)
+
+const (
+	ErrCodeCollectionNotFound = "CollectionNotFound"
+	ErrCodeFeatureNotFound    = "FeatureNotFound"
+)
+
 var ParamReservedNames = []string{
 	ParamLimit,
 	ParamOffset,
@@ -410,24 +429,6 @@ var ConformanceSchema openapi3.Schema = openapi3.Schema{
 		},
 	},
 }
-
-const (
-	ErrMsgEncoding              = "Error encoding response"
-	ErrMsgLoadCollections       = "Unable to access Collections"
-	ErrMsgCollectionNotFound    = "Collection not found: %v"
-	ErrMsgCollectionAccess      = "Unable to access Collection: %v"
-	ErrMsgFeatureNotFound       = "Feature not found: %v"
-	ErrMsgLoadFunctions         = "Unable to access Functions"
-	ErrMsgFunctionNotFound      = "Function not found: %v"
-	ErrMsgFunctionAccess        = "Unable to access Function: %v"
-	ErrMsgInvalidParameterValue = "Invalid value for parameter %v: %v"
-	ErrMsgDataRead              = "Unable to read data from: %v"
-)
-
-const (
-	ErrCodeCollectionNotFound = "CollectionNotFound"
-	ErrCodeFeatureNotFound    = "FeatureNotFound"
-)
 
 var conformance = Conformance{
 	ConformsTo: []string{

--- a/data/catalog_db.go
+++ b/data/catalog_db.go
@@ -53,7 +53,7 @@ var isFunctionsLoaded bool
 var instanceDB catalogDB
 var templateFeature *template.Template
 
-const fmtQueryStats = "Query result: %v rows in %v"
+const fmtQueryStats = "Database query result: %v rows in %v"
 
 func init() {
 	isStartup = true

--- a/util.go
+++ b/util.go
@@ -14,11 +14,13 @@ package main
 */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/CrunchyData/pg_featureserv/api"
 	"github.com/CrunchyData/pg_featureserv/conf"
@@ -54,6 +56,26 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// --- log the request
 	log.Printf("%v %v %v\n", r.RemoteAddr, r.Method, r.URL)
 
+	// signal for normal completion of handler
+	handlerDone := make(chan struct{})
+	start := time.Now()
+
+	// monitor context status and log anything abnormal
+	go func() {
+		select {
+		case <-handlerDone:
+			log.Debugf("---- Request complete in %v", time.Since(start))
+		case <-r.Context().Done():
+			// log cancelations
+			switch r.Context().Err() {
+			case context.DeadlineExceeded:
+				log.Warnf("---- Request processing terminated by write timeout after %v", time.Since(start))
+			case context.Canceled:
+				log.Debugf("---- Request cancelled by client after %v", time.Since(start))
+			}
+		}
+	}()
+
 	// execute the handler
 	e := fn(w, r)
 
@@ -63,8 +85,10 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// log error here?
 		// should log attached error?
 		// panic on severe error?
+		log.Debugf("Request processing error: %v (%v)\n", e.Message, e.Code)
 		http.Error(w, e.Message, e.Code)
 	}
+	close(handlerDone)
 }
 
 func appErrorMsg(err error, msg string, code int) *appError {


### PR DESCRIPTION
This improves the way the service handles timeouts (reported in #35).

* uses [`TimeoutHandler`](https://golang.org/pkg/net/http/#TimeoutHandler) to force-cancel request handling if the write timeout is exceeded.  This reports an error to the client after the timeout
* logs a warning for request timeout if it occurs (so service admins can notice if this should be addressed)
* adds some debug logging about database and request timings

It uses ideas from [this post](https://ieftimov.com/post/make-resilient-golang-net-http-servers-using-timeouts-deadlines-context-cancellation/) and the Go [TimeoutHandler code](https://golang.org/src/net/http/server.go?s=100541:100609#L3256).

Still needed: cancelling database processing if timeout occurs.