### PR TITLE
Add DB driver cancellation using Context

### DIFF
--- a/data/catalog.go
+++ b/data/catalog.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -28,11 +29,11 @@ type Catalog interface {
 
 	// TableFeatures returns an array of the JSON for the features in a table
 	// It returns nil if the table does not exist
-	TableFeatures(name string, param *QueryParam) ([]string, error)
+	TableFeatures(ctx context.Context, name string, param *QueryParam) ([]string, error)
 
 	// TableFeature returns the JSON text for a table feature with given id
 	// It returns an empty string if the table or feature does not exist
-	TableFeature(name string, id string, param *QueryParam) (string, error)
+	TableFeature(ctx context.Context, name string, id string, param *QueryParam) (string, error)
 
 	Functions() ([]*Function, error)
 
@@ -40,9 +41,9 @@ type Catalog interface {
 	// It returns nil if the function does not exist
 	FunctionByName(name string) (*Function, error)
 
-	FunctionFeatures(name string, args map[string]string, param *QueryParam) ([]string, error)
+	FunctionFeatures(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]string, error)
 
-	FunctionData(name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error)
+	FunctionData(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error)
 
 	Close()
 }

--- a/data/catalog_mock.go
+++ b/data/catalog_mock.go
@@ -14,6 +14,7 @@ package data
 */
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -193,7 +194,7 @@ func (cat *CatalogMock) TableByName(name string) (*Table, error) {
 	return nil, nil
 }
 
-func (cat *CatalogMock) TableFeatures(name string, param *QueryParam) ([]string, error) {
+func (cat *CatalogMock) TableFeatures(ctx context.Context, name string, param *QueryParam) ([]string, error) {
 	features, ok := cat.tableData[name]
 	if !ok {
 		// table not found - indicated by nil value returned
@@ -209,7 +210,7 @@ func (cat *CatalogMock) TableFeatures(name string, param *QueryParam) ([]string,
 	return featuresToJSON(featuresLim, propNames), nil
 }
 
-func (cat *CatalogMock) TableFeature(name string, id string, param *QueryParam) (string, error) {
+func (cat *CatalogMock) TableFeature(ctx context.Context, name string, id string, param *QueryParam) (string, error) {
 	features, ok := cat.tableData[name]
 	if !ok {
 		// table not found - indicated by empty value returned
@@ -248,12 +249,12 @@ func (cat *CatalogMock) FunctionByName(name string) (*Function, error) {
 	return nil, nil
 }
 
-func (cat *CatalogMock) FunctionFeatures(name string, args map[string]string, param *QueryParam) ([]string, error) {
+func (cat *CatalogMock) FunctionFeatures(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]string, error) {
 	// TODO:
 	return nil, nil
 }
 
-func (cat *CatalogMock) FunctionData(name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error) {
+func (cat *CatalogMock) FunctionData(ctx context.Context, name string, args map[string]string, param *QueryParam) ([]map[string]interface{}, error) {
 	// TODO:
 	return nil, nil
 }

--- a/handler.go
+++ b/handler.go
@@ -14,6 +14,7 @@ package main
 */
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/CrunchyData/pg_featureserv/api"
@@ -263,9 +264,10 @@ func handleCollectionItems(w http.ResponseWriter, r *http.Request) *appError {
 	param := createQueryParams(&reqParam, tbl.Columns)
 	param.Filter = parseFilter(reqParam.Values, tbl.DbTypes)
 
+	ctx := r.Context()
 	switch format {
 	case api.FormatJSON:
-		return writeItemsJSON(w, name, param, urlBase)
+		return writeItemsJSON(ctx, w, name, param, urlBase)
 	case api.FormatHTML:
 		return writeItemsHTML(w, tbl, name, query, urlBase)
 	}
@@ -291,9 +293,9 @@ func writeItemsHTML(w http.ResponseWriter, tbl *data.Table, name string, query s
 	return writeHTML(w, nil, context, ui.PageItems())
 }
 
-func writeItemsJSON(w http.ResponseWriter, name string, param *data.QueryParam, urlBase string) *appError {
+func writeItemsJSON(ctx context.Context, w http.ResponseWriter, name string, param *data.QueryParam, urlBase string) *appError {
 	//--- query features data
-	features, err := catalogInstance.TableFeatures(name, param)
+	features, err := catalogInstance.TableFeatures(ctx, name, param)
 	if err != nil {
 		return appErrorInternalFmt(err, api.ErrMsgDataRead, name)
 	}
@@ -341,9 +343,10 @@ func handleItem(w http.ResponseWriter, r *http.Request) *appError {
 	}
 	param := createQueryParams(&reqParam, tbl.Columns)
 
+	ctx := r.Context()
 	switch format {
 	case api.FormatJSON:
-		return writeItemJSON(w, name, fid, param, urlBase)
+		return writeItemJSON(ctx, w, name, fid, param, urlBase)
 	case api.FormatHTML:
 		return writeItemHTML(w, tbl, name, fid, query, urlBase)
 	}
@@ -370,9 +373,9 @@ func writeItemHTML(w http.ResponseWriter, tbl *data.Table, name string, fid stri
 	return writeHTML(w, nil, context, ui.PageItem())
 }
 
-func writeItemJSON(w http.ResponseWriter, name string, fid string, param *data.QueryParam, urlBase string) *appError {
+func writeItemJSON(ctx context.Context, w http.ResponseWriter, name string, fid string, param *data.QueryParam, urlBase string) *appError {
 	//--- query data for request
-	feature, err := catalogInstance.TableFeature(name, fid, param)
+	feature, err := catalogInstance.TableFeature(ctx, name, fid, param)
 	if err != nil {
 		return appErrorInternalFmt(err, api.ErrMsgDataRead, name)
 	}
@@ -572,12 +575,13 @@ func handleFunctionItems(w http.ResponseWriter, r *http.Request) *appError {
 	fnArgs := restrict(reqParam.Values, fn.InNames)
 	//log.Debugf("Function request args: %v ", fnArgs)
 
+	ctx := r.Context()
 	switch format {
 	case api.FormatJSON:
 		if fn.IsGeometryFunction() {
-			return writeFunItemsGeoJSON(w, name, fnArgs, param, urlBase)
+			return writeFunItemsGeoJSON(ctx, w, name, fnArgs, param, urlBase)
 		}
-		return writeFunItemsJSON(w, name, fnArgs, param)
+		return writeFunItemsJSON(ctx, w, name, fnArgs, param)
 	case api.FormatHTML:
 		return writeFunItemsHTML(w, name, query, urlBase)
 	}
@@ -609,9 +613,9 @@ func writeFunItemsHTML(w http.ResponseWriter, name string, query string, urlBase
 	return writeHTML(w, nil, context, ui.PageFunctionItems())
 }
 
-func writeFunItemsGeoJSON(w http.ResponseWriter, name string, args map[string]string, param *data.QueryParam, urlBase string) *appError {
+func writeFunItemsGeoJSON(ctx context.Context, w http.ResponseWriter, name string, args map[string]string, param *data.QueryParam, urlBase string) *appError {
 	//--- query features data
-	features, err := catalogInstance.FunctionFeatures(name, args, param)
+	features, err := catalogInstance.FunctionFeatures(ctx, name, args, param)
 	if err != nil {
 		return appErrorInternalFmt(err, api.ErrMsgDataRead, name)
 	}
@@ -626,9 +630,9 @@ func writeFunItemsGeoJSON(w http.ResponseWriter, name string, args map[string]st
 	return writeJSON(w, api.ContentTypeGeoJSON, content)
 }
 
-func writeFunItemsJSON(w http.ResponseWriter, name string, args map[string]string, param *data.QueryParam) *appError {
+func writeFunItemsJSON(ctx context.Context, w http.ResponseWriter, name string, args map[string]string, param *data.QueryParam) *appError {
 	//--- query features data
-	features, err := catalogInstance.FunctionData(name, args, param)
+	features, err := catalogInstance.FunctionData(ctx, name, args, param)
 	if err != nil {
 		return appErrorInternalFmt(err, api.ErrMsgFunctionAccess, name)
 	}


### PR DESCRIPTION
Now that `TimeoutHandler` allows cancelling long requests, this cancellation can be pushed down to the database driver.  This also respects cancellation by the client (e.g. by a request being terminated).  Go provides the `Context` framework to do this.

This does NOT get down to the database level, however (i.e. to cancel a long-running process on the DB side).  This might be possible using a session-level configuration option via SET.

See also #35