### PR TITLE
cast columns that will be treated as strings to text in SQL query

### DIFF
--- a/data/db_sql.go
+++ b/data/db_sql.go
@@ -138,6 +138,14 @@ func sqlColExpr(name string, dbtype string) string {
 	case forceTextTSVECTOR:
 		return fmt.Sprintf("%s::text", name)
 	}
+
+	// for properties that will be treated as a string in the JSON response,
+	// cast to text.  This allows displaying data types that pgx
+	// does not support out of the box, as long as it can be cast to text.
+	if toJSONTypeFromPG(dbtype) == JSONTypeString {
+		return fmt.Sprintf("%s::text", name)
+	}
+
 	return name
 }
 


### PR DESCRIPTION
I have a potential fix for #51 . This PR modifies the property column SQL function to add a `::text` cast if the column is going be treated as a string in the JSON response (according to `toJSONTypeFromPG`). This allows displaying data that jackc/pgx doesn't have built-in support for.

I tested with some data already on my machine as well as a test table containing `ltree` data but I don't have a lot of data with more types that pgx doesn't support.

