### PR TITLE
Fix https/http mixing for https environments

### DIFF
--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -178,7 +178,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 					Responses: openapi3.Responses{
 						"200": &openapi3.ResponseRef{
 							// TODO: Find better OpenAPI schema ref?
-							Ref: "http://json-schema.org/draft-07/schema",
+							Ref: "https://json-schema.org/draft-07/schema",
 						},
 					},
 				},


### PR DESCRIPTION
Hello,

Thank you in advance for your awesome software. 

We have discovered a little bug in https environments. It's placed in following path in the swagger api:

/api.html#/default/getAPI

The browser console is complaining about mixing http in an https environment

" Mixed Content: The page at 'https://----/api.html#/default/getAPI' was loaded over HTTPS, but requested an insecure resource 'http://json-schema.org/draft-07/schema'. This request has been blocked; the content must be served over HTTPS."

See also the following screenshot.

![screenshot](https://user-images.githubusercontent.com/5648254/114703968-511b6500-9d26-11eb-9e60-2deff11b9bd8.JPG)


I hope you can fin this fix useful and can accept our pull request.

KR

Jon

