### PR TITLE
Add descriptions to 200 responses

### DIFF
--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -164,6 +164,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Ref: "",
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchema(&RootInfoSchema),
+								Description: "Results for root of API",
 							},
 						},
 					},
@@ -193,6 +194,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 						"200": &openapi3.ResponseRef{
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchema(&ConformanceSchema),
+								Description: "Results for conformance classes",
 							},
 						},
 					},
@@ -208,6 +210,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchemaRef(
 									&openapi3.SchemaRef{Value: &CollectionsInfoSchema}),
+								Description: "Results for details about the specified feature collection",
 							},
 						},
 					},
@@ -225,6 +228,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchemaRef(
 									&openapi3.SchemaRef{Value: &CollectionInfoSchema}),
+								Description: "Results for details about the specified feature collection",
 							},
 						},
 					},
@@ -319,6 +323,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchemaRef(
 									&openapi3.SchemaRef{Value: &FunctionsInfoSchema}),
+								Description: "Results for details about functions served",
 							},
 						},
 					},
@@ -339,6 +344,8 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 									&openapi3.SchemaRef{
 										Value: &FunctionInfoSchema,
 									}),
+								Description: "Results for details about the specified function",
+
 							},
 						},
 					},

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -178,7 +178,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 					Responses: openapi3.Responses{
 						"200": &openapi3.ResponseRef{
 							// TODO: Find better OpenAPI schema ref?
-							Ref: "http://json-schema.org/draft-07/schema",
+							Ref: "https://json-schema.org/draft-07/schema",
 						},
 					},
 				},


### PR DESCRIPTION
Hello, 
I hope you can find the following PR useful. It adds a "Description" to the 200 reponses in swagger api where missing. In other case we have the following errors in swagger validator.

![image](https://user-images.githubusercontent.com/5648254/123598070-6582e000-d7f4-11eb-808c-ccfb9e0c57bb.png)

And therefore the following message in our API landing page.

![image](https://user-images.githubusercontent.com/5648254/123598198-88ad8f80-d7f4-11eb-8ba2-814514b7821b.png)


KR

@trucheromayor 
