### PR TITLE
fix: getFeature error if primary key column name starts with number

### DIFF
--- a/internal/data/db_sql.go
+++ b/internal/data/db_sql.go
@@ -170,7 +170,7 @@ func sqlColExpr(name string, dbtype string) string {
 	return name
 }
 
-const sqlFmtFeature = "SELECT %v %v FROM \"%s\".\"%s\" WHERE %v = $1 LIMIT 1"
+const sqlFmtFeature = "SELECT %v %v FROM \"%s\".\"%s\" WHERE \"%v\" = $1 LIMIT 1"
 
 func sqlFeature(tbl *Table, param *QueryParam) string {
 	geomCol := sqlGeomCol(tbl.GeometryColumn, param)


### PR DESCRIPTION
Hello,
We have guid column names in our geom tables and we've seen some fails on /collections/{collectionId}/items/{featureId}
This Line fixes the issue

Have a great day and thanks for this project !