### PR TITLE
add docker build suggestion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ go build
 * This creates a `pg_featureserv` executable in the application directory
 * (Optional) Run the unit tests using `go test ./...`
 
+### Building docker image
+
+You should build the executable with:
+```bash
+CGO_ENABLED=0 go build
+```
+To avoid runtime error `/lib64/libc.so.6: version 'GLIBC_2.XX' not found (required by ./pg_featureserv)`.
+
+Then, from `$GOPATH/src/github.com/CrunchyData/pg_featureserv/` directory, build the image with:
+```bash
+docker build -f container/Dockerfile --build-arg VERSION=<VERSION> -t crunchydata/pg_featureserv:<VERSION> ./
+```
+Replace version `<VERSION>` with the `pg_featureserv` version are building against.
+
 ## Configuring the service
 
 * Set the environment variable `DATABASE_URL` with a Postgres [connection string](https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNSTRING)


### PR DESCRIPTION
add docker build instruction to avoid `/lib64/libc.so.6: version 'GLIBC_2.XX' not found` error.