### PR TITLE
Add ability to set BasePath

### DIFF
--- a/config/pg_featureserv.toml.example
+++ b/config/pg_featureserv.toml.example
@@ -16,6 +16,10 @@ HttpPort = 9000
 # Note: do not add a trailing slash.
 #    UrlBase = "http://localhost:9000"
 
+# Optional path to add to the service base URL
+# If set, all routes will be prefixed with this path
+# BasePath = "/"
+
 # String to return for Access-Control-Allow-Origin header
 #    CORSOrigins = "*"
 

--- a/config/pg_featureserv.toml.example
+++ b/config/pg_featureserv.toml.example
@@ -18,6 +18,9 @@ HttpPort = 9000
 
 # Optional path to add to the service base URL
 # If set, all routes will be prefixed with this path
+# (e.g. "/pg_featureserv", "/services/pg_featureserv", etc.)
+# Note: No trailing slash is necessary, pg_featureserv automatically
+# adds a trailing slash for you.
 # BasePath = "/"
 
 # String to return for Access-Control-Allow-Origin header

--- a/hugo/content/installation/configuration.md
+++ b/hugo/content/installation/configuration.md
@@ -45,6 +45,13 @@ HttpPort = 9000
 # Note: do not add a trailing slash.
 # UrlBase = "http://localhost:9000/"
 
+# Optional path to add to the service base URL
+# If set, all routes will be prefixed with this path
+# (e.g. "/pg_featureserv", "/services/pg_featureserv", etc.)
+# Note: No trailing slash is necessary, pg_featureserv automatically
+# adds a trailing slash for you.
+# BasePath = "/"
+
 # String to return for Access-Control-Allow-Origin header
 # CORSOrigins = "*"
 
@@ -124,6 +131,18 @@ UrlBase = https://my-server.org/features
 If `UrlBase` is not set, `pg_featureserv` dynamically detects the base URL.
 Also, if the HTTP headers `Forwarded` or `X-Forwarded-Proto` and `X-Forwarded-Host` are present, they are respected.
 Otherwise the base URL is determined by inspecting the incoming request.
+
+#### BasePath
+
+The BasePath allows an user to change the endpoint where pg_featureserv is served from.
+If `BasePath` is not set, all traffic is served from the root of the website `localhost:9000/`.
+
+##### Example
+```
+BasePath = "/services/pg_featureserv"
+```
+
+All traffic would then be served from `localhost:9000/services/pg_featurserv`.
 
 #### CORSOrigins
 

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -31,6 +31,7 @@ func setDefaultConfig() {
 	viper.SetDefault("Server.TlsServerCertificateFile", "")
 	viper.SetDefault("Server.TlsServerPrivateKeyFile", "")
 	viper.SetDefault("Server.UrlBase", "")
+	viper.SetDefault("Server.BasePath", "")
 	viper.SetDefault("Server.CORSOrigins", "*")
 	viper.SetDefault("Server.Debug", false)
 	viper.SetDefault("Server.AssetsPath", "./assets")
@@ -64,6 +65,7 @@ type Server struct {
 	TlsServerCertificateFile string
 	TlsServerPrivateKeyFile  string
 	UrlBase                  string
+	BasePath				 string
 	CORSOrigins              string
 	Debug                    bool
 	AssetsPath               string

--- a/internal/service/empty_base_path_test.go
+++ b/internal/service/empty_base_path_test.go
@@ -1,0 +1,41 @@
+package service
+
+/*
+ Copyright 2019 Crunchy Data Solutions, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRootEmptyBasePath(t *testing.T) {
+	basePath = ""
+	setup(basePath)
+	Initialize()
+
+	testCases := []string{
+        "/",
+		"/index.html",
+
+    }
+	for _, tc := range testCases {
+        t.Run(fmt.Sprintf("%s route works with empty base path", tc), func(t *testing.T) {
+            resp := doRequest(t, tc)
+			assert(t, resp.Code == 200, "Status must be 200")
+        })
+    }
+
+	basePath = "/pg_featureserv"
+	setup(basePath)
+	Initialize()
+}

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -33,7 +33,7 @@ const (
 func initRouter(basePath string) *mux.Router {
 	router := mux.NewRouter().
 	StrictSlash(true).
-	PathPrefix("/" + strings.TrimLeft(basePath, "/")).
+	PathPrefix("/" + strings.TrimRight(strings.TrimLeft(basePath, "/"), "/")).
 	Subrouter()
 
 	addRoute(router, "/", handleRoot)

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -16,6 +16,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/CrunchyData/pg_featureserv/internal/api"
 	"github.com/CrunchyData/pg_featureserv/internal/conf"
@@ -29,8 +30,11 @@ const (
 	routeVarFeatureID = "fid"
 )
 
-func initRouter() *mux.Router {
-	router := mux.NewRouter().StrictSlash(true)
+func initRouter(basePath string) *mux.Router {
+	router := mux.NewRouter().
+	StrictSlash(true).
+	PathPrefix("/" + strings.TrimLeft(basePath, "/")).
+	Subrouter()
 
 	addRoute(router, "/", handleRoot)
 	addRoute(router, "/home{.fmt}", handleRoot)

--- a/internal/service/handler_test.go
+++ b/internal/service/handler_test.go
@@ -77,7 +77,7 @@ var catalogMock *data.CatalogMock
 func TestMain(m *testing.M) {
 	catalogMock = data.CatMockInstance()
 	catalogInstance = catalogMock
-	router = initRouter()
+	router = initRouter("/")
 	conf.Configuration = testConfig
 	Initialize()
 

--- a/internal/service/handler_test.go
+++ b/internal/service/handler_test.go
@@ -93,7 +93,7 @@ func TestRoot(t *testing.T) {
 	var v api.RootInfo
 	json.Unmarshal(body, &v)
 
-	checkLink(t, v.Links[0], api.RelSelf, api.ContentTypeJSON, urlBase+"/"+api.RootPageName)
+	checkLink(t, v.Links[0], api.RelSelf, api.ContentTypeJSON, urlBase+"//"+api.RootPageName)
 	checkLink(t, v.Links[1], api.RelAlt, api.ContentTypeHTML, urlBase+"/"+api.RootPageName+".html")
 	checkLink(t, v.Links[2], api.RelServiceDesc, api.ContentTypeOpenAPI, urlBase+"/api")
 	checkLink(t, v.Links[3], api.RelConformance, api.ContentTypeJSON, urlBase+"/conformance")
@@ -105,28 +105,6 @@ func TestRoot(t *testing.T) {
 		fmt.Println(v.Title)
 		fmt.Println(v.Description)
 	*/
-}
-
-func TestRootEmptyBasePath(t *testing.T) {
-	basePath = ""
-	setup(basePath)
-	Initialize()
-
-	testCases := []string{
-        "/",
-		"/index.html",
-
-    }
-	for _, tc := range testCases {
-        t.Run(fmt.Sprintf("%s route works with empty base path", tc), func(t *testing.T) {
-            resp := doRequest(t, tc)
-			assert(t, resp.Code == 200, "Status must be 200")
-        })
-    }
-
-	basePath = "/pg_featureserv"
-	setup(basePath)
-	Initialize()
 }
 
 func TestCollectionsResponse(t *testing.T) {

--- a/internal/service/handler_test.go
+++ b/internal/service/handler_test.go
@@ -51,39 +51,39 @@ type FeatureCollection struct {
 const urlBase = "http://test"
 var basePath = "/pg_featureserv"
 
-
-// testConfig is a config spec for using in running tests
-var testConfig conf.Config = conf.Config{
-	Server: conf.Server{
-		HttpHost:   "0.0.0.0",
-		HttpPort:   9000,
-		UrlBase:    urlBase,
-		BasePath:	basePath,
-		AssetsPath: "../../assets",
-		TransformFunctions: []string{
-			"ST_Centroid",
-			"ST_PointOnSurface",
-		},
-	},
-	Paging: conf.Paging{
-		LimitDefault: 10,
-		LimitMax:     1000,
-	},
-	Metadata: conf.Metadata{
-		Title:       "test",
-		Description: "test",
-	},
-}
-
 var catalogMock *data.CatalogMock
 
 func TestMain(m *testing.M) {
 	catalogMock = data.CatMockInstance()
 	catalogInstance = catalogMock
-	router = initRouter(basePath)
-	conf.Configuration = testConfig
+	setup(basePath)
 	Initialize()
 	os.Exit(m.Run())
+}
+
+func setup(path string){
+	router = initRouter(path)
+	conf.Configuration = conf.Config{
+		Server: conf.Server{
+			HttpHost:   "0.0.0.0",
+			HttpPort:   9000,
+			UrlBase:    urlBase,
+			BasePath:	path,
+			AssetsPath: "../../assets",
+			TransformFunctions: []string{
+				"ST_Centroid",
+				"ST_PointOnSurface",
+			},
+		},
+		Paging: conf.Paging{
+			LimitDefault: 10,
+			LimitMax:     1000,
+		},
+		Metadata: conf.Metadata{
+			Title:       "test",
+			Description: "test",
+		},
+	}
 }
 
 func TestRoot(t *testing.T) {
@@ -109,28 +109,7 @@ func TestRoot(t *testing.T) {
 
 func TestRootEmptyBasePath(t *testing.T) {
 	basePath = ""
-	router = initRouter(basePath)
-	conf.Configuration = conf.Config{
-		Server: conf.Server{
-			HttpHost:   "0.0.0.0",
-			HttpPort:   9000,
-			UrlBase:    urlBase,
-			BasePath:	basePath,
-			AssetsPath: "../../assets",
-			TransformFunctions: []string{
-				"ST_Centroid",
-				"ST_PointOnSurface",
-			},
-		},
-		Paging: conf.Paging{
-			LimitDefault: 10,
-			LimitMax:     1000,
-		},
-		Metadata: conf.Metadata{
-			Title:       "test",
-			Description: "test",
-		},
-	}
+	setup(basePath)
 	Initialize()
 
 	testCases := []string{
@@ -144,6 +123,10 @@ func TestRootEmptyBasePath(t *testing.T) {
 			assert(t, resp.Code == 200, "Status must be 200")
         })
     }
+
+	basePath = "/pg_featureserv"
+	setup(basePath)
+	Initialize()
 }
 
 func TestCollectionsResponse(t *testing.T) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -49,13 +49,13 @@ func createServers() {
 	// Use HTTPS only if server certificate and private key files specified
 	isTLSEnabled = conf.Configuration.IsTLSEnabled()
 
-	log.Infof("Serving HTTP  at %s", bindAddress)
+	log.Infof("Serving HTTP  at %s", formatBaseURL("http://", bindAddress, confServ.BasePath))
 	if isTLSEnabled {
-		log.Infof("Serving HTTPS at %s", bindAddressTLS)
+		log.Infof("Serving HTTPS at %s", formatBaseURL("https://", bindAddressTLS, confServ.BasePath))
 	}
 	log.Infof("CORS Allowed Origins: %v\n", conf.Configuration.Server.CORSOrigins)
 
-	router = initRouter()
+	router = initRouter(confServ.BasePath)
 
 	// writeTimeout is slighlty longer than request timeout to allow writing error response
 	timeoutSecRequest := conf.Configuration.Server.WriteTimeoutSec

--- a/internal/service/util.go
+++ b/internal/service/util.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -211,6 +212,24 @@ func urlPathFormatQuery(urlBase string, path string, format string, query string
 		url = fmt.Sprintf("%v?%v", url, query)
 	}
 	return url
+}
+
+// formatBaseURL takes a hostname (baseHost) and a base path
+// and joins them.  Both are parsed as URLs (using net/url) and
+// then joined to ensure a properly formed URL.
+// net/url does not support parsing hostnames without a scheme
+// (e.g. example.com is invalid; http://example.com is valid).
+// serverURLHost ensures a scheme is added.
+func formatBaseURL(protocol string, baseHost string, basePath string) string {
+	urlHost, err := url.Parse(protocol + baseHost)
+	if err != nil {
+		log.Fatal(err)
+	}
+	urlPath, err := url.Parse(basePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return strings.TrimRight(urlHost.ResolveReference(urlPath).String(), "/")
 }
 
 // restrict creates a map containing only entries in names

--- a/internal/service/util.go
+++ b/internal/service/util.go
@@ -175,7 +175,7 @@ func serveURLBase(r *http.Request) string {
 		ps = fp[0]
 	}
 
-	return fmt.Sprintf("%v://%v/", ps, ph)
+	return fmt.Sprintf("%v://%v%v", ps, ph, conf.Configuration.Server.BasePath)
 }
 
 func getRequestVar(varname string, r *http.Request) string {

--- a/internal/service/util.go
+++ b/internal/service/util.go
@@ -175,7 +175,7 @@ func serveURLBase(r *http.Request) string {
 		ps = fp[0]
 	}
 
-	return fmt.Sprintf("%v://%v%v", ps, ph, conf.Configuration.Server.BasePath)
+	return fmt.Sprintf("%v://%v%v", ps, ph, strings.TrimRight(conf.Configuration.Server.BasePath, "/"))
 }
 
 func getRequestVar(varname string, r *http.Request) string {


### PR DESCRIPTION
Adds in BasePath functionality which lets a user set where traffic is served from. This allows the user to serve traffic at spots other than the default base path of `/`. For example, `BasePath = /api/pg_featureserv` would tell `pg_featureserv` to serve all traffic from `localhost:9000/api/pg_featureserv` instead of `localhost:9000/`.

Closes #61 