### PR TITLE
Add Servers object to openApiModel

### DIFF
--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -31,6 +31,8 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 	}
 	log.Debugf("API base path = %v", apiBase)
 
+	servername := u.Scheme + "://" + u.Host
+
 	paramCollectionID := openapi3.ParameterRef{
 		Value: &openapi3.Parameter{
 			Description:     "ID of collection.",
@@ -151,6 +153,11 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 				Name: "Apache 2.0",
 				URL:  "http://www.apache.org/licenses/LICENSE-2.0",
 			},
+		},
+		Servers: openapi3.Servers{
+		 &openapi3.Server{
+			 URL: servername,
+		 },
 		},
 		Paths: openapi3.Paths{
 			apiBase: &openapi3.PathItem{

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -164,6 +164,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Ref: "",
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchema(&RootInfoSchema),
+								Description: "Results for root of API",
 							},
 						},
 					},
@@ -193,6 +194,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 						"200": &openapi3.ResponseRef{
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchema(&ConformanceSchema),
+								Description: "Results for conformance classes",
 							},
 						},
 					},
@@ -208,6 +210,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchemaRef(
 									&openapi3.SchemaRef{Value: &CollectionsInfoSchema}),
+								Description: "Results for details about the specified feature collection",
 							},
 						},
 					},
@@ -225,6 +228,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchemaRef(
 									&openapi3.SchemaRef{Value: &CollectionInfoSchema}),
+								Description: "Results for details about the specified feature collection",
 							},
 						},
 					},
@@ -319,6 +323,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 							Value: &openapi3.Response{
 								Content: openapi3.NewContentWithJSONSchemaRef(
 									&openapi3.SchemaRef{Value: &FunctionsInfoSchema}),
+								Description: "Results for details about functions served",
 							},
 						},
 					},
@@ -339,6 +344,8 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 									&openapi3.SchemaRef{
 										Value: &FunctionInfoSchema,
 									}),
+								Description: "Results for details about the specified function",
+
 							},
 						},
 					},

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -178,7 +178,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 					Responses: openapi3.Responses{
 						"200": &openapi3.ResponseRef{
 							// TODO: Find better OpenAPI schema ref?
-							Ref: "http://json-schema.org/draft-07/schema",
+							Ref: "https://json-schema.org/draft-07/schema",
 						},
 					},
 				},


### PR DESCRIPTION
Hello,

I hope you can accept this PR. We have detected an issue when passing Features API OGC tests. At analyzing /conformance path step, pg_featureserv based APIs fail in the case you have added a baseUrl not matching a pure hostname in your toml configuration.  Our current failing service is like the following:

![image](https://user-images.githubusercontent.com/5648254/140273492-754ed801-100e-423b-8397-b4a485160b6d.png)

As you can see there is a "/features" in the middle of the path. Another example we have found is the [following](https://www.hillcrestgeo.ca/fwapg/api.html). 

This fix is adding an openapi "Servers" object so that we have the following:

![image](https://user-images.githubusercontent.com/5648254/140273744-fbc41805-cc68-469c-864d-d9250147ac50.png)

With this change, we can pass the OGC test at this "/conformance" test.

More information about the OGC test can be found here:

- OGC tests: https://cite.opengeospatial.org/teamengine/
- Specific Features Api test: https://github.com/opengeospatial/ets-ogcapi-features10
- Our proposal of PR for the previous test [here](https://github.com/opengeospatial/ets-ogcapi-features10/pull/179)

Thanks in advance

Jon Garrido,

