### PR TITLE
Add query parameters `crs` and `bbox-crs` 

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -36,7 +36,7 @@ It includes [*OGC API - Features*](http://docs.opengeospatial.org/is/17-069r3/17
 - [x] `crs=srid`
 - [x] `bbox=x1,y1,x2,y2`
 - [ ] `bbox` (6 numbers)
-- [x] `bbox-crs`
+- [x] `bbox-crs=srid`
 - [ ] `datetime`
 - [x] `properties` list
   - restricts properties included in response

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -33,11 +33,13 @@ It includes [*OGC API - Features*](http://docs.opengeospatial.org/is/17-069r3/17
 ### Query parameters - Standard
 - [x] `limit=n`
 - [x] `offset=n`
-- [x] `bbox` (4 numbers)
+- [x] `crs=srid`
+- [x] `bbox=x1,y1,x2,y2`
 - [ ] `bbox` (6 numbers)
-- [ ] `bbox-crs`
+- [x] `bbox-crs`
 - [ ] `datetime`
-- [x] `properties` list (to restrict attributes in response)
+- [x] `properties` list
+  - restricts properties included in response
 - [x] `sortby` to sort output by a property
   - `sortby=name`, `sortby=+name`, `sortby=-name`
 - [x] filtering by property value ( `name=value`, as per [spec sec. 7.15.5](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_parameters_for_filtering_on_feature_properties) )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pg_featureserv Version History
 
-## Version NEXT
+## Version 1.3
 *Released: TBD*
 
 ### New Features
@@ -13,6 +13,7 @@
 * Add configuration to include/exclude published schemas and tables
 * Add configuration for web UI map view basemap URL template
 * Add configuration to set base path (#88)
+* Add standard query parameters `crs` and `bbox-crs` (#98)
 
 ### Performance Improvements
 

--- a/hugo/content/introduction/definitions.md
+++ b/hugo/content/introduction/definitions.md
@@ -19,10 +19,18 @@ A database that includes a "geometry" column type. The PostGIS extension to Post
 
 ### Web API
 
-An Application Program Interface (API) allows client software to make programmatic requests to a service and retrieve information from it.
+An **Application Program Interface** (API) allows client software to make programmatic requests to a service and retrieve information from it.
 
 A Web API is an API founded on Web technologies. These include:
 
 * Use of the HTTP protocol to provide high-level semantics for operations, as well as efficient mechanisms for querying, security and transporting data to clients
 * Following the REST paradigm to simplify the model of interacting with data
 * Using the standard JSON and GeoJSON formats as the primary way of encoding data
+
+### CRS
+
+A **Coordinate Reference System** (CRS) specifies how coordinate values in feature geometries map to locations on the earth's surface.  In PostGIS coordinate systems are identified by numeric SRID values (Spatial Reference Identifiers).
+The available SRIDS are defined in the
+[SPATIAL_REF_SYS table](https://postgis.net/docs/using_postgis_dbmanagement.html#spatial_ref_sys_table).
+By default `pg_featureserv` provides data in the WGS84 geodetic coordinate system (SRID=4326).
+Other coordinates systems can be used in `bbox` queries and for response data.

--- a/hugo/content/usage/query_data.md
+++ b/hugo/content/usage/query_data.md
@@ -39,9 +39,16 @@ If the source data has a non-geographic coordinate system,
 the bounding box is transformed to the source coordinate system
 to perform the query.
 
+A bounding box in a different coordinate system may be specified
+by adding the `bbox-crs=SRID` query parameter.
+
 #### Example
 ```
 http://localhost:9000/collections/ne.countries/items?bbox=10.4,43.3,26.4,47.7
+```
+
+```
+http://localhost:9000/collections/ne.countries/items?bbox-crs=3005&bbox=1000000,400000,1001000,401000
 ```
 
 ### Filter by properties
@@ -56,7 +63,7 @@ to be filtered.  The value of the parameter is the desired property value.
 http://localhost:9000/collections/ne.countries/items?continent=Europe
 ```
 
-### Specify respones properties
+### Specify responses properties
 
 The query parameter `properties=PROP1,PROP2,PROP3...`
 specifies the feature properties returned in the response.
@@ -68,6 +75,23 @@ no feature properties are returned.
 #### Example
 ```
 http://localhost:9000/collections/ne.countries/items?properties=name,abbrev,pop_est
+```
+
+### Specify response coordinate system
+
+The query parameter `crs=SRID`
+specifies the coordinate system to be used for the
+feature geometry in the response.
+The SRID must be a coordinate system which is defined in the PostGIS instance.
+By default data is returned in WGS84 (SRID=4326) geodetic coordinate system.
+
+Note: GeoJSON technically does not support coordinate systems other than 4326,
+but the OGC API standard allows non-geodetic data to be encoded in GeoJSON.
+However, this data may not be compatible with other systems.
+
+#### Example
+```
+http://localhost:9000/collections/bc.rivers/items?crs=3005
 ```
 
 ### Limiting and paging
@@ -126,13 +150,24 @@ The response is a GeoJSON feature containing the result.
 http://localhost:9000/collections/ne.countries/items/23
 ```
 
-### Restrict properties
+### Specify properties
 
 The query parameter `properties=PROP1,PROP2,PROP3...`
-restricts the properties which are returned
+specifies the feature properties which are returned
 in the response.
 
 #### Example
 ```
 http://localhost:9000/collections/ne.countries/items/23?properties=name,abbrev,pop_est
+```
+
+### Specify coordinate system
+
+The query parameter `crs=SRID`
+can be included to specify the coordinate system to be used for the
+feature geometry.
+
+#### Example
+```
+http://localhost:9000/collections/bc.rivers/items/23?crs=3005
 ```

--- a/hugo/content/usage/query_function.md
+++ b/hugo/content/usage/query_function.md
@@ -46,7 +46,10 @@ If the source data has a non-geographic coordinate system
 the bounding box is transformed to the source coordinate system
 to perform the query.
 
-This parameter is only useful for spatial functions.
+A bounding box in a different coordinate system may be specified
+by adding the `bbox-crs=SRID` query parameter.
+
+This parameter is only useful for **spatial** functions.
 
 #### Example
 ```
@@ -65,6 +68,23 @@ no feature properties are returned.
 #### Example
 ```
 http://localhost:9000/functions/countries_name/items?properties=name
+```
+
+### Specify response coordinate system
+
+The query parameter `crs=SRID`
+specifies the coordinate system to be used for the
+feature geometry in the response.
+The SRID must be a coordinate system which is defined in the PostGIS instance.
+By default data is returned in WGS84 (SRID=4326) geodetic coordinate system.
+
+Note: GeoJSON technically does not support coordinate systems other than 4326,
+but the OGC API standard allows non-geodetic data to be encoded in GeoJSON.
+However, this data may not be compatible with other systems.
+
+#### Example
+```
+http://localhost:9000/functions/bc_rivers_by_name/items?name=Fraser&crs=3005
 ```
 
 ### Limiting and paging

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -32,9 +32,11 @@ const (
 
 	TagFunctions = "functions"
 
+	ParamCrs        = "crs"
 	ParamLimit      = "limit"
 	ParamOffset     = "offset"
 	ParamBbox       = "bbox"
+	ParamBboxCrs    = "bbox-crs"
 	ParamGroupBy    = "groupby"
 	ParamOrderBy    = "orderby"
 	ParamPrecision  = "precision"
@@ -86,6 +88,7 @@ const (
 )
 
 var ParamReservedNames = []string{
+	ParamCrs,
 	ParamLimit,
 	ParamOffset,
 	ParamBbox,
@@ -228,9 +231,11 @@ type NameValMap map[string]string
 
 // RequestParam holds the parameters for a request
 type RequestParam struct {
+	Crs           int
 	Limit         int
 	Offset        int
 	Bbox          *data.Extent
+	BboxCrs       int
 	Properties    []string
 	GroupBy       []string
 	SortBy        []data.Sorting

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -70,6 +70,22 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 			AllowEmptyValue: false,
 		},
 	}
+	paramBboxCrs := openapi3.ParameterRef{
+		Value: &openapi3.Parameter{
+			Name:        "bbox-crs",
+			Description: "SRID for coordinate reference system of bbox parameter.",
+			In:          "query",
+			Required:    false,
+			Schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					Type:    "integer",
+					Min:     openapi3.Float64Ptr(1),
+					Default: 4326,
+				},
+			},
+			AllowEmptyValue: false,
+		},
+	}
 	paramProperties := openapi3.ParameterRef{
 		Value: &openapi3.Parameter{
 			Name:        "properties",
@@ -107,6 +123,22 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 			AllowEmptyValue: false,
 		},
 	}
+	paramCrs := openapi3.ParameterRef{
+		Value: &openapi3.Parameter{
+			Name:        "crs",
+			Description: "SRID for coordinate reference system of output features.",
+			In:          "query",
+			Required:    false,
+			Schema: &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					Type:    "integer",
+					Min:     openapi3.Float64Ptr(1),
+					Default: 4326,
+				},
+			},
+			AllowEmptyValue: false,
+		},
+	}
 	paramLimit := openapi3.ParameterRef{
 		Value: &openapi3.Parameter{
 			Name:        "limit",
@@ -116,7 +148,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 			Schema: &openapi3.SchemaRef{
 				Value: &openapi3.Schema{
 					Type:    "integer",
-					Min:     openapi3.Float64Ptr(1),
+					Min:     openapi3.Float64Ptr(0),
 					Max:     openapi3.Float64Ptr(float64(conf.Configuration.Paging.LimitMax)),
 					Default: conf.Configuration.Paging.LimitDefault,
 				},
@@ -173,7 +205,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 						"200": &openapi3.ResponseRef{
 							Ref: "",
 							Value: &openapi3.Response{
-								Content: openapi3.NewContentWithJSONSchema(&RootInfoSchema),
+								Content:     openapi3.NewContentWithJSONSchema(&RootInfoSchema),
 								Description: "Results for root of API",
 							},
 						},
@@ -203,7 +235,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 					Responses: openapi3.Responses{
 						"200": &openapi3.ResponseRef{
 							Value: &openapi3.Response{
-								Content: openapi3.NewContentWithJSONSchema(&ConformanceSchema),
+								Content:     openapi3.NewContentWithJSONSchema(&ConformanceSchema),
 								Description: "Results for conformance classes",
 							},
 						},
@@ -253,7 +285,9 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 						&paramCollectionID,
 						&paramLimit,
 						&paramOffset,
+						&paramCrs,
 						&paramBbox,
+						&paramBboxCrs,
 						&paramProperties,
 						&paramSortBy,
 						&paramTransform,
@@ -306,6 +340,7 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 						},
 						&paramProperties,
 						&paramTransform,
+						&paramCrs,
 					},
 					Responses: openapi3.Responses{
 						"200": &openapi3.ResponseRef{
@@ -356,7 +391,6 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 										Value: &FunctionInfoSchema,
 									}),
 								Description: "Results for details about the specified function",
-
 							},
 						},
 					},
@@ -371,7 +405,9 @@ func GetOpenAPIContent(urlBase string) *openapi3.Swagger {
 						&paramFunctionID,
 						&paramLimit,
 						&paramOffset,
+						&paramCrs,
 						&paramBbox,
+						&paramBboxCrs,
 						&paramProperties,
 						&paramSortBy,
 						&paramTransform,

--- a/internal/conf/appconfig.go
+++ b/internal/conf/appconfig.go
@@ -13,7 +13,7 @@ package conf
  limitations under the License.
 */
 
-var setVersion string = "1.2"
+var setVersion string = "1.3"
 
 // AppConfiguration is the set of global application configuration constants.
 type AppConfiguration struct {

--- a/internal/data/catalog.go
+++ b/internal/data/catalog.go
@@ -19,6 +19,12 @@ import (
  limitations under the License.
 */
 
+const (
+	//errMsgCollectionNotFound = "Collection not found: %v"
+	//errMsgFeatureNotFound    = "Feature not found: %v"
+	SRID_4326 = 4326
+)
+
 // Catalog tbd
 type Catalog interface {
 	SetIncludeExclude(includeList []string, excludeList []string)
@@ -71,10 +77,12 @@ type FilterCond struct {
 
 // QueryParam holds the optional parameters for a data query
 type QueryParam struct {
-	Limit  int
-	Offset int
-	Bbox   *Extent
-	Filter []*FilterCond
+	Crs     int
+	Limit   int
+	Offset  int
+	Bbox    *Extent
+	BboxCrs int
+	Filter  []*FilterCond
 	// Columns is the list of columns to return
 	Columns       []string
 	GroupBy       []string
@@ -124,11 +132,6 @@ type Function struct {
 	GeometryColumn string
 	IDColumn       string
 }
-
-const (
-	errMsgCollectionNotFound = "Collection not found: %v"
-	errMsgFeatureNotFound    = "Feature not found: %v"
-)
 
 func (fun *Function) IsGeometryFunction() bool {
 	for _, typ := range fun.OutDbTypes {

--- a/internal/data/db_sql.go
+++ b/internal/data/db_sql.go
@@ -210,17 +210,17 @@ func sqlAttrFilter(filterConds []*FilterCond) (string, []interface{}) {
 const sqlFmtBBoxTransformFilter = ` ST_Intersects("%v", ST_Transform( ST_MakeEnvelope(%v, %v, %v, %v, %v), %v)) `
 const sqlFmtBBoxGeoFilter = ` ST_Intersects("%v", ST_MakeEnvelope(%v, %v, %v, %v, %v)) `
 
-func sqlBBoxFilter(geomCol string, srcSRID int, bbox *Extent, bboxCrs int) string {
+func sqlBBoxFilter(geomCol string, srcSRID int, bbox *Extent, bboxSRID int) string {
 	if bbox == nil {
 		return ""
 	}
-	if srcSRID == bboxCrs {
+	if srcSRID == bboxSRID {
 		return fmt.Sprintf(sqlFmtBBoxGeoFilter, geomCol,
-			bbox.Minx, bbox.Miny, bbox.Maxx, bbox.Maxy, bboxCrs)
+			bbox.Minx, bbox.Miny, bbox.Maxx, bbox.Maxy, bboxSRID)
 	}
-	//-- transform to src CRS so spatial index is used
+	//-- transform bbox to src CRS so spatial index is used
 	return fmt.Sprintf(sqlFmtBBoxTransformFilter, geomCol,
-		bbox.Minx, bbox.Miny, bbox.Maxx, bbox.Maxy, bboxCrs,
+		bbox.Minx, bbox.Miny, bbox.Maxx, bbox.Maxy, bboxSRID,
 		srcSRID)
 }
 

--- a/testing/pgfs_test.md
+++ b/testing/pgfs_test.md
@@ -1,0 +1,13 @@
+# pg_fetaureserv Test Queries
+
+## CRS handling
+
+'''
+http://localhost:9000/collections/pgfs_test.test_crs/items.json?crs=3005
+
+http://localhost:9000/collections/pgfs_test.test_crs/items.json?crs=3005&bbox-crs=3005&bbox=1000000,400000,1010000,410000
+Response: 1 feature
+
+http://localhost:9000/collections/pgfs_test.test_crs/items.json?crs=3005&bbox-crs=3005&bbox=1000000,400000,1030000,430000
+Response: 4 features
+'''

--- a/testing/pgfs_test.sql
+++ b/testing/pgfs_test.sql
@@ -9,6 +9,29 @@ CREATE SCHEMA pgfs_test;
 
 --=====================================================================
 
+CREATE TABLE pgfs_test.test_crs
+(
+    id integer primary key,
+    geom geometry(polygon, 3005),
+    name text
+);
+
+-- DROP TABLE pgfs_test.test_crs;
+-- DELETE FROM pgfs_test.test_crs;
+
+INSERT INTO pgfs_test.test_crs
+SELECT ROW_NUMBER() OVER () AS id,
+        ST_MakeEnvelope(1000000.0 + 20000 * x, 400000.0 + 20000 * y,
+                        1000000.0 + 20000 * (x + 1), 400000.0 + 20000 * (y + 1),
+            3005) AS geom,
+        x || '_' || y AS name
+  FROM generate_series(0, 9) AS x(x)
+  CROSS JOIN generate_series(0, 9) AS y(y);
+
+ß
+
+--=====================================================================
+
 CREATE TABLE pgfs_test.test_json
 (
     id integer primary key,


### PR DESCRIPTION
(See Design issue #6 and feature request #97)

Adds standard OAPIF query parameters:
* `crs=n` - specifies CRS of response data
* `bbox-crs=n` - specifies CRS of `bbox` parameter values

Both accept `int` params giving the PostGIS SRID.

### Notes
* Does not add queries for CRS metadata 