### PR TITLE
Allow configuring published function schemas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Add configuration for web UI map view basemap URL template
 * Add configuration to set base path (#88)
 * Add standard query parameters `crs` and `bbox-crs` (#98)
+* Allow configuring published function schemas (#99)
 
 ### Performance Improvements
 

--- a/config/pg_featureserv.toml.example
+++ b/config/pg_featureserv.toml.example
@@ -65,6 +65,9 @@ WriteTimeoutSec = 30
 # Do not publish these schemas and tables
 # TableExcludes = [ "priv_schema", "public.my_tbl" ]
 
+# Publish functions from these schemas (default is publish postgisftw)
+# FunctionIncludes = [ "postgisftw", "schema2" ]
+
 [Paging]
 # The default number of features in a response
 LimitDefault = 20

--- a/hugo/content/examples/ex_query_functions_locate_country.md
+++ b/hugo/content/examples/ex_query_functions_locate_country.md
@@ -5,11 +5,12 @@ draft: false
 weight: 220
 ---
 
-Non-spatial functions (i.e. functions that don't return spatial data) can also be accessed via `pg_featureserv`, as long as they are published in the `postgisftw` schema.
+Non-spatial functions (i.e. functions that don't return spatial data) can also be accessed via `pg_featureserv`, as long as they are published in a configured schema
+(by default, all functions in the `postgisftw` schema are published).
 
 The following function example can be used with the `ne.countries` collection created in the [Quick Start](/quickstart/) section. It shows a function that accepts longitude and latitude values, and returns the corresponding country (if any). Unlike the other function examples in this section, it does not return a table with a geometry type column.
 
-Any kind of function in the `postgisftw` schema is published, which allows you even more flexible access to data. You can create functions that return statistics, summary records, populate dropdown lists or autocomplete suggestions, and more.
+Any kind of function can be published, which allows you very flexible access to data. You can create functions that return statistics, summary records, populate dropdown lists or autocomplete suggestions, and more.
 
 ## Create a non-spatial function that locates the country for a given coordinate pair
 
@@ -38,13 +39,13 @@ Notes:
 
 * The function generates a [Point](https://postgis.net/docs/ST_MakePoint.html) based on the longitude and latitude values provided in the parameters.
 * The `ne.countries` table is filtered based on whether the point [intersects](https://postgis.net/docs/ST_Intersects.html) a country polygon.
-* It's possible that a point lies exactly on the boundary between two countries. Both country records will be included in the query result set, but `LIMIT 1` restricts the result to a single record. 
+* It's possible that a point lies exactly on the boundary between two countries. Both country records will be included in the query result set, but `LIMIT 1` restricts the result to a single record.
 
 ## Example of API query
 
 The coordinate pair (47,8) can be passed into the function:
 
-`http://localhost:9000/functions/country_by_loc/items.json?lat=47&lon=8`
+`http://localhost:9000/functions/postgisftw.country_by_loc/items.json?lat=47&lon=8`
 
 ## Sample JSON response
 

--- a/hugo/content/installation/configuration.md
+++ b/hugo/content/installation/configuration.md
@@ -189,6 +189,21 @@ such as `1d`, `2.5h`, or `30m`.
 
 The maximum number of database connections held in the connection pool.
 
+#### TableIncludes
+
+A list of schemas and tables to publish feature collections from.
+The default is to include all geometry tables.
+
+#### TableExcludes
+
+A list of schemas and tables not to publish.
+Overrides items specified in `TableIncludes`.
+
+#### FunctionIncludes
+
+A list of schemas to publish functions from.
+The default is to publish functions in `postgisftw`.
+
 #### LimitDefault
 
 The default number of features in a response,

--- a/hugo/content/usage/functions.md
+++ b/hugo/content/usage/functions.md
@@ -34,7 +34,9 @@ or the equivalent (and more standard) `TABLE`
 (see the Postgres manual section on [set-returning functions](https://www.postgresql.org/docs/current/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET).)
 
 Because there are usually many functions in a Postgres database,
-the service only publishes functions defined in the `postgisftw` schema.
+the service only publishes functions defined in the schemas
+specified in the `FunctionIncludes` configuration setting.
+By default the functions in the `postgisftw` schema are published.
 
 A function specifies zero or more input parameters.
 An input parameter can be of any Postgres type
@@ -106,7 +108,7 @@ The function can be called via the API by providing a value for the `name_prefix
 (which could be omitted, due to the presence of a default value):
 
 ```
-http://localhost:9000/functions/countries_name/items?name_prefix=T
+http://localhost:9000/functions/postgisftw.countries_name/items?name_prefix=T
 ```
 
 The response is a GeoJSON document containing the 13 countries starting with the letter 'T'.
@@ -142,7 +144,7 @@ are published from only one schema.
 
 #### Example
 ```
-http://localhost:9000/functions/geonames_geom
+http://localhost:9000/functions/postgisftw.geonames_geom
 ```
 
 The response is a JSON document containing metadata about the function, including:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -558,7 +558,7 @@ func NewFunctionsInfo(fns []*data.Function) *FunctionsInfo {
 
 func NewFunctionSummary(fn *data.Function) *FunctionSummary {
 	info := FunctionSummary{
-		Name:        fn.Name,
+		Name:        fn.ID,
 		Description: fn.Description,
 		Function:    fn,
 	}
@@ -567,7 +567,7 @@ func NewFunctionSummary(fn *data.Function) *FunctionSummary {
 
 func NewFunctionInfo(fn *data.Function) *FunctionInfo {
 	info := FunctionInfo{
-		Name:        fn.Name,
+		Name:        fn.ID,
 		Description: fn.Description,
 		Function:    fn,
 	}

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -44,6 +44,7 @@ func setDefaultConfig() {
 
 	viper.SetDefault("Database.DbPoolMaxConnLifeTime", "1h")
 	viper.SetDefault("Database.DbPoolMaxConns", 4)
+	viper.SetDefault("Database.FunctionIncludes", []string{"postgisftw"})
 
 	viper.SetDefault("Metadata.Title", "pg-featureserv")
 	viper.SetDefault("Metadata.Description", "Crunchy Data Feature Server for PostGIS")
@@ -88,6 +89,7 @@ type Database struct {
 	DbPoolMaxConns        int
 	TableIncludes         []string
 	TableExcludes         []string
+	FunctionIncludes      []string
 }
 
 // Metadata config

--- a/internal/data/catalog.go
+++ b/internal/data/catalog.go
@@ -152,3 +152,12 @@ func (fun *TransformFunction) apply(expr string) string {
 	args := strings.Join(fun.Arg, ",")
 	return fmt.Sprintf("%v( %v, %v )", fun.Name, expr, args)
 }
+
+// Creates a fully qualified function id.
+// adds default postgisftw schema if name arg has no schema
+func FunctionQualifiedId(name string) string {
+	if strings.Contains(name, ".") {
+		return name
+	}
+	return SchemaPostGISFTW + "." + name
+}

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -457,7 +457,7 @@ func handleFunctions(w http.ResponseWriter, r *http.Request) *appError {
 		case api.FormatHTML:
 			addFunctionURLs(fn, urlBase, isGeomFun)
 		default:
-			fn.Links = linksFunction(fn.Name, urlBase, true, isGeomFun)
+			fn.Links = linksFunction(fn.Function.ID, urlBase, true, isGeomFun)
 		}
 	}
 
@@ -532,7 +532,7 @@ func handleFunction(w http.ResponseWriter, r *http.Request) *appError {
 	format := api.RequestedFormat(r)
 	urlBase := serveURLBase(r)
 
-	name := getRequestVar(routeVarID, r)
+	name := data.FunctionQualifiedId(getRequestVar(routeVarID, r))
 
 	fn, err := catalogInstance.FunctionByName(name)
 	if fn == nil && err == nil {
@@ -572,7 +572,7 @@ func handleFunctionItems(w http.ResponseWriter, r *http.Request) *appError {
 	urlBase := serveURLBase(r)
 
 	//--- extract request parameters
-	name := getRequestVar(routeVarID, r)
+	name := data.FunctionQualifiedId(getRequestVar(routeVarID, r))
 	reqParam, err := parseRequestParams(r)
 	if err != nil {
 		return appErrorMsg(err, err.Error(), http.StatusBadRequest)
@@ -601,7 +601,6 @@ func handleFunctionItems(w http.ResponseWriter, r *http.Request) *appError {
 	case api.FormatSVG:
 		return writeFunItemsText(ctx, w, api.ContentTypeSVG, name, fnArgs, param)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Adds support to specify multiple schemas that functions are published from.

The schemas are listed in the configuration parameter `FunctionIncludes`. For example:
```
# Publish functions from these schemas (default is publish postgisftw)
FunctionIncludes = [ "postgisftw", "schema2" ]
```
By default, functions from schema `postgisftw` are published (which provides backwards compatibility).

Supporting multiple schemas means that function names must now be qualified by schema name.  For backwards compatibility, unqualified names are mapped to the `postgisftw` schema.