### PR TITLE
Fix geometry function CRS transform

### DIFF
--- a/internal/data/catalog.go
+++ b/internal/data/catalog.go
@@ -22,7 +22,8 @@ import (
 const (
 	//errMsgCollectionNotFound = "Collection not found: %v"
 	//errMsgFeatureNotFound    = "Feature not found: %v"
-	SRID_4326 = 4326
+	SRID_4326    = 4326
+	SRID_UNKNOWN = -1
 )
 
 // Catalog tbd

--- a/internal/data/db_sql.go
+++ b/internal/data/db_sql.go
@@ -327,7 +327,7 @@ const sqlFmtGeomFunction = "SELECT %s %s FROM \"%s\".\"%s\"( %v ) %v %v %s;"
 
 func sqlGeomFunction(fn *Function, args map[string]string, propCols []string, param *QueryParam) (string, []interface{}) {
 	sqlArgs, argVals := sqlFunctionArgs(fn, args)
-	sqlGeomCol := sqlGeomCol(fn.GeometryColumn, SRID_4326, param)
+	sqlGeomCol := sqlGeomCol(fn.GeometryColumn, SRID_UNKNOWN, param)
 	sqlPropCols := sqlColList(propCols, fn.Types, true)
 	//-- SRS of function output is unknown, so have to assume 4326
 	bboxFilter := sqlBBoxFilter(fn.GeometryColumn, SRID_4326, param.Bbox, param.BboxCrs)


### PR DESCRIPTION
Fix a regression bug which was making an assumption that geometry function output is in SRID 4326.  For transforming to the requested output CRS it is not necessary to know the actual CRS returned from the function.

Note that it is still required to make an assumption about function CRS for bbox filtering.  For these kinds of requests the function must transform output internally to 4326.
  
Fixes #114.