### PR TITLE
Upgrade OpenLayers from `v6.1.1` to `v8.2.0`

### DIFF
--- a/assets/map_script.gohtml
+++ b/assets/map_script.gohtml
@@ -1,5 +1,5 @@
 {{define "mapStyle"}}
-<link rel="stylesheet" href="https://openlayers.org/en/v6.1.1/css/ol.css" type="text/css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css" type="text/css">
 
 <style>
 .map {
@@ -112,7 +112,7 @@
     </div>
 {{end}}
 {{define "mapScript"}}
-<script src="https://openlayers.org/en/v6.1.1/build/ol.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
 <script>
 var SHOW_FEATURE_LINK = {{ .context.ShowFeatureLink }};
 var BASEMAP_URL = "{{ .config.Website.BasemapUrl }}";
@@ -133,7 +133,7 @@ var map = new ol.Map({
 		}),
 	],
 	target: 'map',
-	controls: ol.control.defaults({	attribution: false }),
+	controls: ol.control.defaults.defaults({ attribution: false }),
 	view: new ol.View({
 		center: [0,0],
 		zoom: 10

--- a/assets/map_script.gohtml
+++ b/assets/map_script.gohtml
@@ -1,5 +1,5 @@
 {{define "mapStyle"}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css" type="text/css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.2.0/ol.css" type="text/css">
 
 <style>
 .map {
@@ -112,7 +112,7 @@
     </div>
 {{end}}
 {{define "mapScript"}}
-<script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/ol@v8.2.0/dist/ol.js"></script>
 <script>
 var SHOW_FEATURE_LINK = {{ .context.ShowFeatureLink }};
 var BASEMAP_URL = "{{ .config.Website.BasemapUrl }}";

--- a/demo/routing/openlayers-pgrouting.html
+++ b/demo/routing/openlayers-pgrouting.html
@@ -6,8 +6,8 @@
   <title>PgRouting Example</title>
 
   <!-- CSS/JS for OpenLayers map  -->
-  <link rel="stylesheet" href="https://openlayers.org/en/v6.1.1/css/ol.css" type="text/css">
-  <script src="https://openlayers.org/en/v6.1.1/build/ol.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css" type="text/css">
+  <script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
 
   <style>
     body {

--- a/demo/routing/openlayers-pgrouting.html
+++ b/demo/routing/openlayers-pgrouting.html
@@ -6,8 +6,8 @@
   <title>PgRouting Example</title>
 
   <!-- CSS/JS for OpenLayers map  -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css" type="text/css">
-  <script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.2.0/ol.css" type="text/css">
+  <script src="https://cdn.jsdelivr.net/npm/ol@v8.2.0/dist/ol.js"></script>
 
   <style>
     body {


### PR DESCRIPTION
- only minor code adaptation was needed to perform the upgrade
- upgrade should not change anything in the UI
- change source of OpenLayers library  from https://openlayers.org to https://cdn.jsdelivr.net was needed, because the OpenLayers website does not seem to provide the library anymore
- the webmap in the `pgrouting` example also still works after the upgrade: https://github.com/CrunchyData/pg_featureserv/blob/master/demo/routing/openlayers-pgrouting.html
