### PR TITLE
Map view: make more space for crumbs

### DIFF
--- a/assets/map_script.gohtml
+++ b/assets/map_script.gohtml
@@ -4,7 +4,7 @@
 <style>
 .map {
     position: absolute;
-    top: 72px;
+    top: 82px;
     bottom: 0px;
     left: 0px;
     right: 0px;
@@ -52,7 +52,7 @@
 }
 .mw-title {
     position: absolute;
-    top: 85px;
+    top: 95px;
     left: 50px;
     border-radius: 8px;
     padding: 5px 10px 5px 10px;
@@ -60,7 +60,7 @@
 }
 .mw-query-params {
     position: absolute;
-    top: 145px;
+    top: 155px;
     left: 0px;
     border-radius: 0px 8px 8px 0px;
     border-left: 0px;


### PR DESCRIPTION
- makes more space at the bottom of the crumbs by moving the map some pixels down
- can be seen at the `JSON` button

**before:**
![image](https://github.com/CrunchyData/pg_featureserv/assets/15704517/a2a1c2a2-24fb-4fbf-a3fc-da65814e5785)


**after:**
![image](https://github.com/CrunchyData/pg_featureserv/assets/15704517/efe3a158-9e20-406b-8ffd-e36d655186f3)

