### PR TITLE
Map view: ensure data extent is set on start

### DIFF
--- a/assets/map_script.gohtml
+++ b/assets/map_script.gohtml
@@ -117,40 +117,70 @@
 var SHOW_FEATURE_LINK = {{ .context.ShowFeatureLink }};
 var BASEMAP_URL = "{{ .config.Website.BasemapUrl }}";
 
-var vectorLayer = new ol.layer.Vector({
-	source: new ol.source.Vector({
-	  url: DATA_URL,
-	  format: new ol.format.GeoJSON()
-	}),
-	style: styleFunction
-  });
-var map = new ol.Map({
-	layers: [
-		new ol.layer.Tile({
-			source: new ol.source.OSM({
-				"url" : BASEMAP_URL
-			})
-		}),
-	],
-	target: 'map',
-	controls: ol.control.defaults({	attribution: false }),
-	view: new ol.View({
-		center: [0,0],
-		zoom: 10
-	})
-});
-map.addLayer(vectorLayer);
+var map
+var vectorLayer
 
-map.once('rendercomplete', function(event) {
-	zoomLayer(vectorLayer);
-	onMapLoad();
-});
-map.on('pointermove', (evt) => {
+// we download the data first to be able to set the correct
+// extent of the map right at the start
+var xhr = new XMLHttpRequest();
+xhr.open('GET', DATA_URL, true);
+xhr.responseType = 'json';
+xhr.onload = function() {
+  if (xhr.status === 200) {
+    var result = xhr.response;
+    initMap(result);
+  } else {
+    var error = 'Loading feature(s) failed\n' + xhr.statusText;
+    alert(error);
+    console.error(error);
+  }
+};
+xhr.send();
+
+function initMap(geojson) {
+    const olFeatures = new ol.format.GeoJSON().readFeatures(
+        geojson,
+        {
+            featureProjection: 'EPSG:3857'
+        }
+    )
+    const vectorSource =  new ol.source.Vector({
+        features: olFeatures,
+    })
+
+    vectorLayer = new ol.layer.Vector({
+        source: vectorSource,
+        style: styleFunction
+    });
+
+    const extent = vectorSource.getExtent()
+
+    map = new ol.Map({
+        layers: [
+            new ol.layer.Tile({
+                source: new ol.source.OSM({
+                    "url" : BASEMAP_URL
+                })
+            }),
+            vectorLayer
+        ],
+        target: 'map',
+        controls: ol.control.defaults({ attribution: false }),
+    });
+
+    zoomExtent(extent)
+
+    map.once('rendercomplete', function(event) {
+        onMapLoad();
+    });
+    map.on('pointermove', (evt) => {
         let ptGeo = ol.proj.transform(evt.coordinate, 'EPSG:3857', 'EPSG:4326');
         let pFormat = ol.coordinate.toStringXY(ptGeo, 4);
         let divPos = document.getElementById('map-mousepos');
         divPos.innerHTML = pFormat + '  : ' + map.getView().getZoom().toFixed(0) ;
     });
+}
+
 function onFeatureClick(evt) {
 	var features = map.getFeaturesAtPixel(evt.pixel);
 	var loc = evt.coordinate;
@@ -166,9 +196,12 @@ function zoomLayer(lyr) {
 	zoomExtent( lyr.getSource().getExtent() );
 }
 function zoomExtent(extent) {
-	let sz = Math.max( ol.extent.getWidth(extent), ol.extent.getHeight(extent) );
-	let zoomext = ol.extent.buffer( extent,  0.2 * sz);
-    map.getView().fit(zoomext, map.getSize());
+    map.getView().fit(
+        extent,
+        {
+          padding: [100, 100, 100, 100]
+        }
+    );
 }
 function extentGeo() {
 	var extent = map.getView().calculateExtent(map.getSize());


### PR DESCRIPTION
- before when the map was loaded the extent was initially at null island and jumped afterwards to the extent of the data. see GIFs below. I find this a bit distracting and confusing.
- this PR ensures the map has the data extent directly at the start by loading the data first and initializing the map afterwards
- for loading the data the very ancient [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest) was chosen to guarantee maximum browser compatibility. However we could also use the more modern [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch) approach. 

**before:**

![ol-before](https://github.com/CrunchyData/pg_featureserv/assets/15704517/e72d1349-d9a2-4b31-a133-10a48ad21b71)

**after:**

![ol_after](https://github.com/CrunchyData/pg_featureserv/assets/15704517/51f4b9b3-72c0-4c0d-aa74-7a446cd6371b)
