### PR TITLE
Support unnesting of JSONB fields

### DIFF
--- a/internal/data/catalog_db.go
+++ b/internal/data/catalog_db.go
@@ -42,6 +42,7 @@ const (
 	PGTypeBool      = "bool"
 	PGTypeNumeric   = "numeric"
 	PGTypeJSON      = "json"
+	PGTypeJSONB     = "jsonb"
 	PGTypeGeometry  = "geometry"
 	PGTypeTextArray = "_text"
 )
@@ -538,6 +539,8 @@ func toJSONTypeFromPG(pgType string) string {
 	case PGTypeBool:
 		return JSONTypeBoolean
 	case PGTypeJSON:
+		return JSONTypeJSON
+	case PGTypeJSONB:
 		return JSONTypeJSON
 	case PGTypeTextArray:
 		return JSONTypeStringArray


### PR DESCRIPTION
Minor fix to unnest values from JSONB fields in GeoJSON output.

Output before:

```json
{
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Polygon",
                "coordinates": [
                    [
                        [
                            8.9000685,
                            53.1099145
                        ],
                        [
                            8.9001737,
                            53.109878
                        ],
                        [
                            8.9002618,
                            53.1099697
                        ],
                        [
                            8.9001565,
                            53.1100061
                        ],
                        [
                            8.9000685,
                            53.1099145
                        ]
                    ]
                ]
            },
            "properties": {
                "osm_id": 249727578,
                "osm_type": "W",
                "tags": "{\"club\": \"sport\", \"name\": \"BTC - Borgfelder Tennisclub\", \"building\": \"yes\"}" <-- HERE
            }
        }
    ],
    "numberReturned": 1,
    "timeStamp": "2024-03-31T19:25:21+02:00",
    "links": [
        {
            "href": "http://localhost:9000/collections/postgisftw.osm_feature_info/items",
            "rel": "self",
            "type": "application/json",
            "title": "This document as JSON"
        },
        {
            "href": "http://localhost:9000/collections/postgisftw.osm_feature_info/items.html",
            "rel": "alternate",
            "type": "text/html",
            "title": "This document as HTML"
        }
    ]
}
```

Output after:

```json
{
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Polygon",
                "coordinates": [
                    [
                        [
                            8.9000685,
                            53.1099145
                        ],
                        [
                            8.9001737,
                            53.109878
                        ],
                        [
                            8.9002618,
                            53.1099697
                        ],
                        [
                            8.9001565,
                            53.1100061
                        ],
                        [
                            8.9000685,
                            53.1099145
                        ]
                    ]
                ]
            },
            "properties": {
                "osm_id": 249727578,
                "osm_type": "W",
                "tags": {    <-- HERE
                    "building": "yes",
                    "club": "sport",
                    "name": "BTC - Borgfelder Tennisclub"
                }
            }
        }
    ],
    "numberReturned": 1,
    "timeStamp": "2024-03-31T19:22:09+02:00",
    "links": [
        {
            "href": "http://localhost:9000/collections/postgisftw.osm_feature_info/items",
            "rel": "self",
            "type": "application/json",
            "title": "This document as JSON"
        },
        {
            "href": "http://localhost:9000/collections/postgisftw.osm_feature_info/items.html",
            "rel": "alternate",
            "type": "text/html",
            "title": "This document as HTML"
        }
    ]
}
```