### PR TITLE
Landing page (HTML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The example requests assume that the service is running locally and configured
 to listen on port 9000.
 
 - Landing page (HTML or JSON): http://localhost:9000/
-- Landing page (HTML): http://localhost:9000/index,html
+- Landing page (HTML): http://localhost:9000/index.html
 - Landing page (JSON): http://localhost:9000/index.json
 - OpenAPI definition: http://localhost:9000/api
 - OpenAPI test UI: http://localhost:9000/api.html


### PR DESCRIPTION
hotfix in Landing page (HTML) , replaced `http://localhost:9000/index,html` with `http://localhost:9000/index.html`