### PR TITLE
Update the Collection extent to be a 2d array instead of a 1d array

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -195,7 +195,7 @@ var ParameterSchema openapi3.Schema = openapi3.Schema{
 // Bbox for extent
 type Bbox struct {
 	Crs    string    `json:"crs"`
-	Extent []float64 `json:"bbox"`
+	Extent [][]float64 `json:"bbox"`
 }
 
 // Extent OAPIF Extent structure (partial)
@@ -490,7 +490,7 @@ func toBbox(cc *data.Table) *Bbox {
 	crs := "http://www.opengis.net/def/crs/EPSG/0/4326"
 	return &Bbox{
 		Crs:    crs,
-		Extent: []float64{cc.Extent.Minx, cc.Extent.Miny, cc.Extent.Maxx, cc.Extent.Maxy},
+		Extent: [][]float64{{cc.Extent.Minx, cc.Extent.Miny, cc.Extent.Maxx, cc.Extent.Maxy}},
 	}
 }
 

--- a/internal/service/util.go
+++ b/internal/service/util.go
@@ -262,7 +262,7 @@ func writeJSON(w http.ResponseWriter, contype string, content interface{}) *appE
 		log.Printf("JSON encoding error: %v", err.Error())
 		return appErrorInternal(err, api.ErrMsgEncoding)
 	}
-	// fmt.Println(string(encodedContent))
+	//fmt.Println(string(encodedContent))
 	writeResponse(w, contype, encodedContent)
 	return nil
 }

--- a/internal/service/util.go
+++ b/internal/service/util.go
@@ -262,7 +262,7 @@ func writeJSON(w http.ResponseWriter, contype string, content interface{}) *appE
 		log.Printf("JSON encoding error: %v", err.Error())
 		return appErrorInternal(err, api.ErrMsgEncoding)
 	}
-	//fmt.Println(string(encodedContent))
+	// fmt.Println(string(encodedContent))
 	writeResponse(w, contype, encodedContent)
 	return nil
 }


### PR DESCRIPTION
I am testing with the OGCFeatureLayer from arcgis Core v4.30.9 and noticed that I was unable to get the features to display on the map. After looking through their library, they are expecting the bbox to be a 2d array. Thus when it tries to pull the bbox and sees that it is a 1d array, it tries to access a float and then errors out.

I updated the type of extent to be a 2d array instead of a 1d array and put the same

Code from the OGCFeatureLayer in arcgis Core v4.30.9
```ts
function K(e2) {
  var _a;
  const t = (_a = e2.extent) == null ? void 0 : _a.spatial;
  if (!t) return null;
  const n2 = t.bbox[0], i3 = 4 === n2.length, [r, o2] = n2, s2 = i3 ? void 0 : n2[2];
  return { xmin: r, ymin: o2, xmax: i3 ? n2[2] : n2[3], ymax: i3 ? n2[3] : n2[4], zmin: s2, zmax: i3 ? void 0 : n2[5], spatialReference: f.WGS84.toJSON() };
}