### PR TITLE
HTML items on map template: upgrade OpenLayers from 6.1.1 stale to 6.15.1

### DIFF
--- a/assets/map_script.gohtml
+++ b/assets/map_script.gohtml
@@ -1,5 +1,5 @@
 {{define "mapStyle"}}
-<link rel="stylesheet" href="https://openlayers.org/en/v6.1.1/css/ol.css" type="text/css">
+<link rel="stylesheet" href="https://openlayers.org/en/v6.15.1/css/ol.css" type="text/css">
 
 <style>
 .map {
@@ -112,7 +112,7 @@
     </div>
 {{end}}
 {{define "mapScript"}}
-<script src="https://openlayers.org/en/v6.1.1/build/ol.js"></script>
+<script src="https://openlayers.org/en/v6.15.1/build/ol.js"></script>
 <script>
 var SHOW_FEATURE_LINK = {{ .context.ShowFeatureLink }};
 var BASEMAP_URL = "{{ .config.Website.BasemapUrl }}";


### PR DESCRIPTION
In `assets/map_script.gohtml` the includes: https://openlayers.org/en/v6.1.1/css/ol.css and https://openlayers.org/en/v6.1.1/build/ol.js are stale (404). v6.15.1 is the latest OL v6 build. This fixes that e.g. `/items.html` works again. 

In the longer term: additional issues/PRs here to a higher OL version and maybe serving from a CDN like `jsdelivr`. Or like suggested in issue #149.