### PR TITLE
feature IDs for views (and tables without PK)

### DIFF
--- a/config/pg_featureserv.toml.example
+++ b/config/pg_featureserv.toml.example
@@ -69,7 +69,7 @@ WriteTimeoutSec = 30
 # FunctionIncludes = [ "postgisftw", "schema2" ]
 
 # Designate a column as the feature ID (where primary key is not available e.g. views/functions)
-# IdColumn = "id"
+# IDColumn = "id"
 
 [Paging]
 # The default number of features in a response

--- a/config/pg_featureserv.toml.example
+++ b/config/pg_featureserv.toml.example
@@ -68,6 +68,9 @@ WriteTimeoutSec = 30
 # Publish functions from these schemas (default is publish postgisftw)
 # FunctionIncludes = [ "postgisftw", "schema2" ]
 
+# Designate a column as the feature ID (where primary key is not available e.g. views/functions)
+IdColumn = "id"
+
 [Paging]
 # The default number of features in a response
 LimitDefault = 20

--- a/config/pg_featureserv.toml.example
+++ b/config/pg_featureserv.toml.example
@@ -69,7 +69,7 @@ WriteTimeoutSec = 30
 # FunctionIncludes = [ "postgisftw", "schema2" ]
 
 # Designate a column as the feature ID (where primary key is not available e.g. views/functions)
-IdColumn = "id"
+# IdColumn = "id"
 
 [Paging]
 # The default number of features in a response

--- a/demo/initdb/02-functions.sql
+++ b/demo/initdb/02-functions.sql
@@ -19,7 +19,7 @@ BEGIN
     dlat := (lat_max - lat_min) / num_y;
     RETURN QUERY
         SELECT
-            x.x::text || '_' || y.y::text AS fid,
+            x.x::text || '_' || y.y::text AS id,
             ST_MakeEnvelope(
                 lon_min + (x.x - 1) * dlon, lat_min + (y.y - 1) * dlat,
                 lon_min + x.x * dlon,       lat_min + y.y * dlat, 4326
@@ -35,7 +35,7 @@ COMMENT ON FUNCTION postgisftw.us_grid IS 'Generates a grid of rectangles coveri
 CREATE OR REPLACE FUNCTION postgisftw.us_grid_noid(
     num_x integer DEFAULT 10,
     num_y integer DEFAULT 10)
-RETURNS TABLE(geom geometry)
+RETURNS TABLE(value text, geom geometry)
 AS $$
 DECLARE
     lon_min CONSTANT numeric := -128;
@@ -49,6 +49,7 @@ BEGIN
     dlat := (lat_max - lat_min) / num_y;
     RETURN QUERY
         SELECT
+            x.x::text || '_' || y.y::text AS value,
             ST_MakeEnvelope(
                 lon_min + (x.x - 1) * dlon, lat_min + (y.y - 1) * dlat,
                 lon_min + x.x * dlon,       lat_min + y.y * dlat, 4326

--- a/hugo/content/installation/configuration.md
+++ b/hugo/content/installation/configuration.md
@@ -119,6 +119,9 @@ WriteTimeoutSec = 30
 # Publish functions from these schemas (default is publish postgisftw)
 # FunctionIncludes = [ "postgisftw", "schema2" ]
 
+# Designate a column as the feature ID (where primary key is not available e.g. views/functions)
+IdColumn = "id"
+
 [Paging]
 # The default number of features in a response
 LimitDefault = 20
@@ -242,6 +245,12 @@ Overrides items specified in `TableIncludes`.
 
 A list of the schemas to publish functions from.
 The default is to publish functions in the `postgisftw` schema.
+
+#### IdColumn
+
+The column to use as the feature ID in cases where a primary key is not available. The default is `id`.
+
+> NOTE: The presence of a primary key will supercede this setting.
 
 #### LimitDefault
 

--- a/hugo/content/installation/configuration.md
+++ b/hugo/content/installation/configuration.md
@@ -120,7 +120,7 @@ WriteTimeoutSec = 30
 # FunctionIncludes = [ "postgisftw", "schema2" ]
 
 # Designate a column as the feature ID (where primary key is not available e.g. views/functions)
-# IdColumn = "id"
+# IDColumn = "id"
 
 [Paging]
 # The default number of features in a response
@@ -246,7 +246,7 @@ Overrides items specified in `TableIncludes`.
 A list of the schemas to publish functions from.
 The default is to publish functions in the `postgisftw` schema.
 
-#### IdColumn
+#### IDColumn
 
 The column to use as the feature ID in cases where a primary key is not available. The default is `id`.
 

--- a/hugo/content/installation/configuration.md
+++ b/hugo/content/installation/configuration.md
@@ -120,7 +120,7 @@ WriteTimeoutSec = 30
 # FunctionIncludes = [ "postgisftw", "schema2" ]
 
 # Designate a column as the feature ID (where primary key is not available e.g. views/functions)
-IdColumn = "id"
+# IdColumn = "id"
 
 [Paging]
 # The default number of features in a response

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -44,6 +44,7 @@ func setDefaultConfig() {
 	viper.SetDefault("Database.TableIncludes", []string{})
 	viper.SetDefault("Database.TableExcludes", []string{})
 	viper.SetDefault("Database.FunctionIncludes", []string{"postgisftw"})
+	viper.SetDefault("Database.IdColumn", "id")
 
 	viper.SetDefault("Paging.LimitDefault", 10)
 	viper.SetDefault("Paging.LimitMax", 1000)
@@ -94,6 +95,7 @@ type Database struct {
 	TableIncludes         []string
 	TableExcludes         []string
 	FunctionIncludes      []string
+	IdColumn              string
 }
 
 // Metadata config

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -44,7 +44,7 @@ func setDefaultConfig() {
 	viper.SetDefault("Database.TableIncludes", []string{})
 	viper.SetDefault("Database.TableExcludes", []string{})
 	viper.SetDefault("Database.FunctionIncludes", []string{"postgisftw"})
-	viper.SetDefault("Database.IdColumn", "id")
+	viper.SetDefault("Database.IDColumn", "id")
 
 	viper.SetDefault("Paging.LimitDefault", 10)
 	viper.SetDefault("Paging.LimitMax", 1000)
@@ -95,7 +95,7 @@ type Database struct {
 	TableIncludes         []string
 	TableExcludes         []string
 	FunctionIncludes      []string
-	IdColumn              string
+	IDColumn              string
 }
 
 // Metadata config

--- a/internal/data/catalog_db.go
+++ b/internal/data/catalog_db.go
@@ -355,9 +355,9 @@ func scanTable(rows pgx.Rows) *Table {
 	}
 
 	// detect ID column if primary key not defined.
-	if idColumn == "" && conf.Configuration.Database.IdColumn != "" {
-		if _, ok := datatypes[conf.Configuration.Database.IdColumn]; ok {
-			idColumn = conf.Configuration.Database.IdColumn
+	if idColumn == "" && conf.Configuration.Database.IDColumn != "" {
+		if _, ok := datatypes[conf.Configuration.Database.IDColumn]; ok {
+			idColumn = conf.Configuration.Database.IDColumn
 		}
 	}
 

--- a/internal/data/catalog_db.go
+++ b/internal/data/catalog_db.go
@@ -354,7 +354,7 @@ func scanTable(rows pgx.Rows) *Table {
 		colDesc[i] = props.Elements[elmPos+2].String
 	}
 
-	// default ID column if primary key not defined. check if conf.Configuration.Database.IdColumn is among columns
+	// detect ID column if primary key not defined.
 	if idColumn == "" && conf.Configuration.Database.IdColumn != "" {
 		if _, ok := datatypes[conf.Configuration.Database.IdColumn]; ok {
 			idColumn = conf.Configuration.Database.IdColumn

--- a/internal/data/catalog_db.go
+++ b/internal/data/catalog_db.go
@@ -262,7 +262,7 @@ func tablesSorted(tableMap map[string]*Table) []*Table {
 
 func (cat *catalogDB) readTables(db *pgxpool.Pool) map[string]*Table {
 	log.Debugf("Load table catalog:\n%v", sqlTables)
-	rows, err := db.Query(context.Background(), sqlTables, conf.Configuration.Database.IdColumn)
+	rows, err := db.Query(context.Background(), sqlTables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -352,6 +352,13 @@ func scanTable(rows pgx.Rows) *Table {
 		datatypes[name] = datatype
 		jsontypes[i] = toJSONTypeFromPG(datatype)
 		colDesc[i] = props.Elements[elmPos+2].String
+	}
+
+	// default ID column if primary key not defined. check if conf.Configuration.Database.IdColumn is among columns
+	if idColumn == "" && conf.Configuration.Database.IdColumn != "" {
+		if _, ok := datatypes[conf.Configuration.Database.IdColumn]; ok {
+			idColumn = conf.Configuration.Database.IdColumn
+		}
 	}
 
 	// Synthesize a title for now

--- a/internal/data/catalog_db.go
+++ b/internal/data/catalog_db.go
@@ -262,7 +262,7 @@ func tablesSorted(tableMap map[string]*Table) []*Table {
 
 func (cat *catalogDB) readTables(db *pgxpool.Pool) map[string]*Table {
 	log.Debugf("Load table catalog:\n%v", sqlTables)
-	rows, err := db.Query(context.Background(), sqlTables)
+	rows, err := db.Query(context.Background(), sqlTables, conf.Configuration.Database.IdColumn)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/data/catalog_db_fun.go
+++ b/internal/data/catalog_db_fun.go
@@ -26,7 +26,6 @@ import (
 )
 
 // FunctionIDColumnName is the name for a function-supplied ID
-const FunctionIDColumnName = "id"
 
 const SchemaPostGISFTW = "postgisftw"
 

--- a/internal/data/catalog_db_fun.go
+++ b/internal/data/catalog_db_fun.go
@@ -191,7 +191,7 @@ func (cat *catalogDB) FunctionFeatures(ctx context.Context, name string, args ma
 		return nil, errArg
 	}
 	propCols := removeNames(param.Columns, fn.GeometryColumn, "")
-	idColIndex := indexOfName(propCols, FunctionIDColumnName)
+	idColIndex := indexOfName(propCols, conf.Configuration.Database.IdColumn)
 	sql, argValues := sqlGeomFunction(fn, args, propCols, param)
 	log.Debugf("Function features query: %v", sql)
 	log.Debugf("Function %v Args: %v", name, argValues)

--- a/internal/data/catalog_db_fun.go
+++ b/internal/data/catalog_db_fun.go
@@ -116,9 +116,9 @@ func scanFunctionDef(rows pgx.Rows) *Function {
 	geomCol := geometryColumn(outNames, datatypes)
 
 	idColumn := ""
-	if conf.Configuration.Database.IdColumn != "" {
-		if _, ok := datatypes[conf.Configuration.Database.IdColumn]; ok {
-			idColumn = conf.Configuration.Database.IdColumn
+	if conf.Configuration.Database.IDColumn != "" {
+		if _, ok := datatypes[conf.Configuration.Database.IDColumn]; ok {
+			idColumn = conf.Configuration.Database.IDColumn
 		}
 	}
 

--- a/internal/data/catalog_db_fun.go
+++ b/internal/data/catalog_db_fun.go
@@ -115,6 +115,13 @@ func scanFunctionDef(rows pgx.Rows) *Function {
 
 	geomCol := geometryColumn(outNames, datatypes)
 
+	idColumn := ""
+	if conf.Configuration.Database.IdColumn != "" {
+		if _, ok := datatypes[conf.Configuration.Database.IdColumn]; ok {
+			idColumn = conf.Configuration.Database.IdColumn
+		}
+	}
+
 	funDef := Function{
 		ID:             id,
 		Schema:         schema,
@@ -130,6 +137,7 @@ func scanFunctionDef(rows pgx.Rows) *Function {
 		OutJSONTypes:   outJSONTypes,
 		Types:          datatypes,
 		GeometryColumn: geomCol,
+		IDColumn:       idColumn,
 	}
 	//fmt.Printf("DEBUG: Function definitions: %v\n", funDef)
 	return &funDef
@@ -190,7 +198,7 @@ func (cat *catalogDB) FunctionFeatures(ctx context.Context, name string, args ma
 		return nil, errArg
 	}
 	propCols := removeNames(param.Columns, fn.GeometryColumn, "")
-	idColIndex := indexOfName(propCols, conf.Configuration.Database.IdColumn)
+	idColIndex := indexOfName(propCols, fn.IDColumn)
 	sql, argValues := sqlGeomFunction(fn, args, propCols, param)
 	log.Debugf("Function features query: %v", sql)
 	log.Debugf("Function %v Args: %v", name, argValues)

--- a/internal/data/db_sql.go
+++ b/internal/data/db_sql.go
@@ -31,7 +31,7 @@ const sqlTables = `SELECT
 	a.attname AS geometry_column,
 	postgis_typmod_srid(a.atttypmod) AS srid,
 	postgis_typmod_type(a.atttypmod) AS geometry_type,
-	coalesce(ia.attname, '') AS id_column,
+	coalesce(ia.attname, fid.attname, '') AS id_column,
 	(
 		SELECT array_agg(ARRAY[sa.attname, st.typname, coalesce(da.description,''), sa.attnum::text]::text[] ORDER BY sa.attnum)
 		FROM pg_attribute sa
@@ -50,6 +50,7 @@ LEFT JOIN pg_description d ON (c.oid = d.objoid AND d.objsubid = 0)
 LEFT JOIN pg_index i ON (c.oid = i.indrelid AND i.indisprimary
 AND i.indnatts = 1)
 LEFT JOIN pg_attribute ia ON (ia.attrelid = i.indexrelid)
+LEFT JOIN pg_attribute fid ON (fid.attrelid = c.oid AND fid.attname = 'id' AND fid.attnum > 0 AND NOT fid.attisdropped)
 LEFT JOIN pg_type it ON (ia.atttypid = it.oid AND it.typname in ('int2', 'int4', 'int8'))
 WHERE c.relkind IN ('r', 'v', 'm', 'p', 'f')
 AND t.typname IN ('geometry', 'geography')

--- a/internal/data/db_sql.go
+++ b/internal/data/db_sql.go
@@ -31,7 +31,7 @@ const sqlTables = `SELECT
 	a.attname AS geometry_column,
 	postgis_typmod_srid(a.atttypmod) AS srid,
 	postgis_typmod_type(a.atttypmod) AS geometry_type,
-	coalesce(ia.attname, fid.attname, '') AS id_column,
+	coalesce(ia.attname, '') AS id_column,
 	(
 		SELECT array_agg(ARRAY[sa.attname, st.typname, coalesce(da.description,''), sa.attnum::text]::text[] ORDER BY sa.attnum)
 		FROM pg_attribute sa
@@ -50,7 +50,6 @@ LEFT JOIN pg_description d ON (c.oid = d.objoid AND d.objsubid = 0)
 LEFT JOIN pg_index i ON (c.oid = i.indrelid AND i.indisprimary
 AND i.indnatts = 1)
 LEFT JOIN pg_attribute ia ON (ia.attrelid = i.indexrelid)
-LEFT JOIN pg_attribute fid ON (fid.attrelid = c.oid AND fid.attname = $1 AND fid.attnum > 0 AND NOT fid.attisdropped)
 LEFT JOIN pg_type it ON (ia.atttypid = it.oid AND it.typname in ('int2', 'int4', 'int8'))
 WHERE c.relkind IN ('r', 'v', 'm', 'p', 'f')
 AND t.typname IN ('geometry', 'geography')

--- a/internal/data/db_sql.go
+++ b/internal/data/db_sql.go
@@ -50,7 +50,7 @@ LEFT JOIN pg_description d ON (c.oid = d.objoid AND d.objsubid = 0)
 LEFT JOIN pg_index i ON (c.oid = i.indrelid AND i.indisprimary
 AND i.indnatts = 1)
 LEFT JOIN pg_attribute ia ON (ia.attrelid = i.indexrelid)
-LEFT JOIN pg_attribute fid ON (fid.attrelid = c.oid AND fid.attname = 'id' AND fid.attnum > 0 AND NOT fid.attisdropped)
+LEFT JOIN pg_attribute fid ON (fid.attrelid = c.oid AND fid.attname = $1 AND fid.attnum > 0 AND NOT fid.attisdropped)
 LEFT JOIN pg_type it ON (ia.atttypid = it.oid AND it.typname in ('int2', 'int4', 'int8'))
 WHERE c.relkind IN ('r', 'v', 'm', 'p', 'f')
 AND t.typname IN ('geometry', 'geography')

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -636,7 +636,7 @@ func writeFunItemsHTML(w http.ResponseWriter, name string, query string, urlBase
 	context.Group = "Functions"
 	context.Title = fn.ID
 	context.Function = fn
-	context.IDColumn = data.FunctionIDColumnName
+	context.IDColumn = conf.Configuration.Database.IdColumn
 
 	// features are not needed for items page (page queries for them)
 	return writeHTML(w, nil, context, ui.PageFunctionItems())

--- a/internal/service/handler.go
+++ b/internal/service/handler.go
@@ -636,7 +636,7 @@ func writeFunItemsHTML(w http.ResponseWriter, name string, query string, urlBase
 	context.Group = "Functions"
 	context.Title = fn.ID
 	context.Function = fn
-	context.IDColumn = conf.Configuration.Database.IdColumn
+	context.IDColumn = fn.IDColumn
 
 	// features are not needed for items page (page queries for them)
 	return writeHTML(w, nil, context, ui.PageFunctionItems())


### PR DESCRIPTION
fixes #86 

 * Adds `Database.IDColumn = "id"` to config
 * Use IDColumn to search table columns for a matching name. Use as a fallback for cases where there's no primary key (views, tables w/o pk)
 * Also used to match against function output columns in place of the hard-coded "id" identifier from before

Question: we could make this be `Database.IDColumns = ["id"]` instead to allow for multiple possible options (first match)