### PR TITLE
fix: set a default transform functions value

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -38,6 +38,7 @@ func setDefaultConfig() {
 	viper.SetDefault("Server.AssetsPath", "./assets")
 	viper.SetDefault("Server.ReadTimeoutSec", 5)
 	viper.SetDefault("Server.WriteTimeoutSec", 30)
+	viper.SetDefault("Server.TransformFunctions", []string{})
 
 	viper.SetDefault("Database.DbPoolMaxConnLifeTime", "1h")
 	viper.SetDefault("Database.DbPoolMaxConns", 4)


### PR DESCRIPTION
Fixes #172 

I set the env var `PGFS_SERVER_TRANSFORMFUNCTIONS` as per the [Configuration Using Environment Variables
](https://access.crunchydata.com/documentation/pg_featureserv/latest/installation/configuration/) doc, but it gets ignored.

Adding a default config fixes the issue. I verified the fix in [my docker image](https://hub.docker.com/repository/docker/gulfaraz/pg_featureserv/tags/20260611).